### PR TITLE
content-agnostically join container into a string

### DIFF
--- a/cpp/src/utils/container.h
+++ b/cpp/src/utils/container.h
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <array>
-#include <deque>
-#include <list>
-#include <vector>
-
 #include <sstream>
+#include <string>
 
 namespace Container {
     template<typename cont_T>
     std::string print_container(const cont_T &cont, const std::string &delim = ",") {
-        std::stringstream res;
-        for (const auto &elem: cont) {
-            res << elem;
-            if (elem != cont.back()) res << delim;
-        }
-        return res.str();
+        std::ostringstream r;
+        auto i = cont.begin();
+        auto e = cont.end();
+        if (i == e)
+            return r.str();
+        r << *i++;
+        for ( ; i != e; ++i)
+            r << delim << *i;
+        return r.str();
     }
 }


### PR DESCRIPTION
and remove unused includes.

Before that change the function had the arguably surprising pre-condition that the elements of the container need to be unique.

A caller who violates that pre-condition would get results such as:

    [1 2 3 1] with delim "," => "12,3,1"

instead of the arguably naturally expected:

    [1 2 3 1] with delim "," => "1,2,3,1"

Sure, perhaps your code checks elsewhere that the input is unique, no sane user would ever provide non-unique input etc. But having such a generically named function lying around in the codebase arguably has the risk of being called on non-unique input, at some point, arguably.